### PR TITLE
Gives TERM=dumb Higher Priority

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,10 @@ function supportsColor(stream) {
 
 	const min = forceColor ? 1 : 0;
 
+	if (env.TERM === 'dumb') {
+		return min;
+	}
+
 	if (process.platform === 'win32') {
 		// Node.js 7.5.0 is the first version of Node.js to include a patch to
 		// libuv that enables 256 color output on Windows. Anything earlier and it
@@ -110,10 +114,6 @@ function supportsColor(stream) {
 
 	if ('COLORTERM' in env) {
 		return 1;
-	}
-
-	if (env.TERM === 'dumb') {
-		return min;
 	}
 
 	return min;

--- a/test.js
+++ b/test.js
@@ -317,3 +317,38 @@ test('return level 2 when FORCE_COLOR is set when not TTY in xterm256', t => {
 	t.truthy(result.stdout);
 	t.is(result.stdout.level, 2);
 });
+
+test('return false when `TERM` is set to dumb', t => {
+	process.env.TERM = 'dumb';
+	const result = importFresh('.');
+	t.false(result.stdout);
+});
+
+test('return false when `TERM` is set to dumb when `TERM_PROGRAM` is set', t => {
+	process.env.TERM = 'dumb';
+	process.env.TERM_PROGRAM = 'Apple_Terminal';
+	const result = importFresh('.');
+	t.false(result.stdout);
+});
+
+test('return false when `TERM` is set to dumb when run on Windows', t => {
+	Object.defineProperty(process, 'platform', {
+		value: 'win32'
+	});
+	Object.defineProperty(process.versions, 'node', {
+		value: '10.13.0'
+	});
+	os.release = () => '10.0.14931';
+	process.env.TERM = 'dumb';
+	const result = importFresh('.');
+	t.false(result.stdout);
+});
+
+test('return level 1 when `TERM` is set to dumb when `FORCE_COLOR` is set', t => {
+	process.env.FORCE_COLOR = '1';
+	process.env.TERM = 'dumb';
+	const result = importFresh('.');
+	t.truthy(result.stdout);
+	t.is(result.stdout.level, 1);
+});
+


### PR DESCRIPTION
Rearranges evaluation order so check for dumb terminal precedes other terminal and platform-specific
checks. Will allow Emacs shell to function properly.

Fixes #88